### PR TITLE
Update condition for adding --xvfb to sitespeed args

### DIFF
--- a/tests/http_validator.py
+++ b/tests/http_validator.py
@@ -842,7 +842,7 @@ def get_website_support_from_sitespeed(url, org_domain, configuration, browser, 
 
     sitespeed_arg = f'--shm-size=1g {sitespeed_arg}'
 
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
 
     (_, filename) = get_result(

--- a/tests/page_not_found.py
+++ b/tests/page_not_found.py
@@ -65,7 +65,7 @@ def get_http_content_with_status(url):
             '--browsertime.chrome.includeResponseBodies all --utc true '
             '--browsertime.chrome.args ignore-certificate-errors '
             f'-n {sitespeed_iterations}')
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
 
     sitespeed_arg += ' --postScript chrome-cookies.cjs --postScript chrome-versions.cjs'

--- a/tests/performance_sitespeed_io.py
+++ b/tests/performance_sitespeed_io.py
@@ -208,7 +208,7 @@ def validate_on_mobile_using_validator(url, validator_config):
         f'{url}'
         f'{browertime_plugin_options}'
         )
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         arg = '--xvfb ' + arg
 
     result_dict = get_result_dict(get_result(arg), validator_config['name'])
@@ -283,7 +283,7 @@ def validate_on_desktop_using_validator(url, validator_config):
         f'{url}'
         f'{browertime_plugin_options}'
         )
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         arg = '--xvfb ' + arg
 
     result_dict = get_result_dict(get_result(arg), validator_config['name'])
@@ -316,7 +316,7 @@ def validate_on_desktop(url):
         '--preScript chrome-custom.cjs '
         f'{url}'
         )
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         arg = '--xvfb ' + arg
 
     result_dict = get_result_dict(get_result(arg), 'desktop')
@@ -348,7 +348,7 @@ def validate_on_mobile(url):
         '--preScript chrome-custom.cjs '
         f'{url}'
         )
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         arg = '--xvfb ' + arg
 
     result_dict = get_result_dict(get_result(arg), 'mobile')

--- a/tests/software.py
+++ b/tests/software.py
@@ -90,7 +90,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
 
     sitespeed_arg = f'--shm-size=1g {sitespeed_arg}'
 
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
 
     sitespeed_arg += ' --postScript chrome-cookies.cjs --postScript chrome-versions.cjs'

--- a/tests/tracking_validator.py
+++ b/tests/tracking_validator.py
@@ -767,7 +767,7 @@ def get_rating_from_sitespeed(url, local_translation, global_translation):
 
     sitespeed_arg = '--shm-size=1g -b chrome --plugins.remove screenshot --plugins.remove html --plugins.remove metrics --browsertime.screenshot false --screenshot false --screenshotLCP false --browsertime.screenshotLCP false --chrome.cdp.performance false --browsertime.chrome.timeline false --videoParams.createFilmstrip false --visualMetrics false --visualMetricsPerceptual false --visualMetricsContentful false --browsertime.headless true --browsertime.chrome.includeResponseBodies all --utc true --browsertime.chrome.args ignore-certificate-errors -n {0}'.format(
         sitespeed_iterations)
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
 
     sitespeed_arg += ' --postScript chrome-cookies.cjs --postScript chrome-versions.cjs'

--- a/tests/w3c_base.py
+++ b/tests/w3c_base.py
@@ -108,7 +108,7 @@ def get_data_for_url(url):
             '--browsertime.chrome.includeResponseBodies all --utc true '
             '--browsertime.chrome.args ignore-certificate-errors '
             f'-n {sitespeed_iterations}')
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
 
     sitespeed_arg += ' --postScript chrome-cookies.cjs --postScript chrome-versions.cjs'

--- a/update_software.py
+++ b/update_software.py
@@ -109,7 +109,7 @@ def update_user_agent():
 
     sitespeed_arg = f'--shm-size=1g {sitespeed_arg}'
 
-    if 'nt' not in os.name:
+    if not ('nt' in os.name or 'Darwin' in os.uname().sysname):
         sitespeed_arg += ' --xvfb'
     sitespeed_arg += (f' --outputFolder {result_folder_name} {url}')
 


### PR DESCRIPTION
Previously, the condition handled Windows only. Now it handle both Windows and MacOS.
